### PR TITLE
Update directory matching in key

### DIFF
--- a/keyutils.go
+++ b/keyutils.go
@@ -10,7 +10,11 @@ type keyUtils struct {
 }
 
 func (s *keyUtils) isInDirectory(directory, key string) bool {
-	return strings.HasPrefix(key, directory)
+	parts := strings.Split(key, ".")
+	if len(parts) == 0 {
+		return false
+	}
+	return parts[0] == directory
 }
 
 func (s *keyUtils) normalizeKey(key string) string {

--- a/keyutils_test.go
+++ b/keyutils_test.go
@@ -31,4 +31,14 @@ func TestKey(t *testing.T) {
 		d = u.decodeKey("YQ==.Yg==.MS4xLjEuMQ==")
 		require.Equal(t, "a/b/1.1.1.1", d)
 	})
+	t.Run("dir should not match in key", func(t *testing.T) {
+		u := keyUtils{options: &Config{EncodeKey: true}}
+		isExist := u.isInDirectory("Dashboard", "DashboardCategory.co7663n3vlts3ko6o2pg")
+		require.False(t, isExist)
+	})
+	t.Run("dir should match in key", func(t *testing.T) {
+		u := keyUtils{options: &Config{EncodeKey: true}}
+		isExist := u.isInDirectory("Dashboard", "Dashboard.co7663n3vlts3ko6o2pg")
+		require.True(t, isExist)
+	})
 }


### PR DESCRIPTION
Adjusted the `isInDirectory` function to correctly identify if a key is in a directory, by splitting the key and comparing the first part. Additionally, added two test cases to assert the correct behavior with matching and non-matching keys in directory.